### PR TITLE
Fixes root-ruby-style.gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,83 +1,19 @@
 PATH
   remote: .
   specs:
-    root_ruby_style (0.0.1)
+    root-ruby-style (0.0.1)
+      rubocop (= 0.58.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.2.1)
-      actionview (= 5.2.1)
-      activesupport (= 5.2.1)
-      rack (~> 2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.1)
-      activesupport (= 5.2.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     ast (2.4.0)
-    builder (3.2.3)
-    concurrent-ruby (1.1.3)
-    crass (1.0.4)
-    diff-lcs (1.3)
-    erubi (1.7.1)
-    i18n (1.1.1)
-      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
-    loofah (2.2.3)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
-    method_source (0.9.2)
-    mini_portile2 (2.3.0)
-    minitest (5.11.3)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    rack (2.0.6)
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
-    railties (5.2.1)
-      actionpack (= 5.2.1)
-      activesupport (= 5.2.1)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.1)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-rails (3.8.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
     rubocop (0.58.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -87,19 +23,13 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    thor (0.20.3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  root_ruby_style!
-  rspec-rails (~> 3.8)
-  rubocop (= 0.58.2)
+  root-ruby-style!
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -2,13 +2,12 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
-  gem.name          = "root_ruby_style"
+  gem.name          = "root-ruby-style"
   gem.version       = "0.0.1"
   gem.authors       = ["Root Devs"]
   gem.email         = ["devs@joinroot.com"]
 
   gem.summary       = "Root's Ruby/Rails Style Guide"
 
-  gem.add_development_dependency "rspec-rails", "~> 3.8"
-  gem.add_development_dependency "rubocop", "0.58.2"
+  gem.add_dependency "rubocop", "0.58.2"
 end


### PR DESCRIPTION
There were a couple of issues with this gem's gemspec that I have fixed:

- Incorrect naming–the gem's name was `root_ruby_style` even though the rest of the codebase referred to it as `root-ruby-style`.
- Unused Development Dependency–`rspec-rails` was listed as a development dependency despite it not being used anywhere.
- Incorrect Dependency–`rubocop` was listed as a development dependency instead of a regular dependency.