### PR TITLE
Fixes .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,5 +117,5 @@ Style/WordArray:
   Enabled: false
 
 # UnnecessaryAggregateFailures is off by default because it requires extra configuration within the project that uses it
-RootCop/UnnecessaryAggregateFailures:
+RootCops/UnnecessaryAggregateFailures:
   Enabled: false


### PR DESCRIPTION
I ran a `bundle update` in root-server which updates it's dependency of this gem. When I ran rubocop, I got this error: `RootCop/UnnecessaryAggregateFailures has the wrong namespace - should be RootCops`. This change should remove the error

<!-- probot = {"487052":{"current_lock":false}} -->