### PR TITLE
Adds specs for private methods cops and fixes the broken underscore prefix one

### DIFF
--- a/spec/rubocop/cop/root_cops/private_methods/called_private_method_spec.rb
+++ b/spec/rubocop/cop/root_cops/private_methods/called_private_method_spec.rb
@@ -1,0 +1,47 @@
+require_relative "../../../../spec_helper.rb"
+
+RSpec.describe RuboCop::Cop::RootCops::PrivateMethods::CalledPrivateMethod do
+  subject(:cop) { described_class.new }
+
+  context "when a public class method without arguments is called" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        def some_method
+          SomeClass.a_public_method
+        end
+      RUBY
+    end
+  end
+
+  context "when a public class method with arguments is called" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        def some_method
+          SomeClass.a_public_method(:argument => 1)
+        end
+      RUBY
+    end
+  end
+
+  context "when a 'private' class method without arguments is called" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        def some_method
+          SomeClass._a_private_method
+                    ^^^^^^^^^^^^^^^^^ Do not call private class methods from outside the class. Make the method public if necessary.
+        end
+      RUBY
+    end
+  end
+
+  context "when a 'private' class method with arguments is called" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        def some_method
+          SomeClass._a_private_method(:argument => 1)
+                    ^^^^^^^^^^^^^^^^^ Do not call private class methods from outside the class. Make the method public if necessary.
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/root_cops/private_methods/called_protected_spec.rb
+++ b/spec/rubocop/cop/root_cops/private_methods/called_protected_spec.rb
@@ -1,0 +1,56 @@
+require_relative "../../../../spec_helper.rb"
+
+RSpec.describe RuboCop::Cop::RootCops::PrivateMethods::CalledProtected do
+  subject(:cop) { described_class.new }
+
+  context "when the public modifier is used" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        module FooService
+          public
+
+          def self.method
+            nil
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when the private modifier is used" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        module FooService
+          def self.method
+            _method
+          end
+
+          private
+
+          def self._method
+            nil
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when the protected modifier is used" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        module FooService
+          def self.method
+            _method
+          end
+
+          protected
+          ^^^^^^^^^ Do not use protected. Use private instead.
+
+          def self._method
+            nil
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/root_cops/private_methods/underscore_prefix_spec.rb
+++ b/spec/rubocop/cop/root_cops/private_methods/underscore_prefix_spec.rb
@@ -1,0 +1,197 @@
+require_relative "../../../../spec_helper.rb"
+
+require "pry"
+
+RSpec.describe RuboCop::Cop::RootCops::PrivateMethods::UnderscorePrefix do
+  subject(:cop) { described_class.new }
+
+  shared_examples_for "underscore prefix linting" do
+    context "when writing a method above the private modifier" do
+      context "when using an underscore prefix" do
+        it "reports an offense" do
+          expect_offense(<<~RUBY.strip_indent)
+            #{module_or_class} FooService
+              def self._method
+              ^^^^^^^^^^^^^^^^ Include a private declaration above the private methods.
+                nil
+              end
+
+              def _method
+              ^^^^^^^^^^^ Include a private declaration above the private methods.
+                nil
+              end
+
+              private
+            end
+          RUBY
+        end
+      end
+
+      context "when not using an underscore prefix" do
+        it "does not report an offense" do
+          expect_no_offenses(<<~RUBY.strip_indent)
+            #{module_or_class} FooService
+              def self.method
+                nil
+              end
+
+              def method
+                nil
+              end
+
+              private
+            end
+          RUBY
+        end
+      end
+    end
+
+    context "when writing a method below the private modifier" do
+      context "when not using an underscore prefix" do
+        it "reports an offense" do
+          expect_offense(<<~RUBY.strip_indent)
+            #{module_or_class} FooService
+              private
+
+              def self.method
+              ^^^^^^^^^^^^^^^ Prefix private method names with an underscore. If method should be public, move it above the private scope.
+                nil
+              end
+
+              def method
+              ^^^^^^^^^^ Prefix private method names with an underscore. If method should be public, move it above the private scope.
+                nil
+              end
+            end
+          RUBY
+        end
+      end
+
+      context "when using an underscore prefix" do
+        it "does not report an offense" do
+          expect_no_offenses(<<~RUBY.strip_indent)
+            #{module_or_class} FooService
+              private
+
+              def self._method
+                nil
+              end
+
+              def _method
+                nil
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context "when in an inner-class/module under a private modifier" do
+      context "when writing a method above the private modifier" do
+        context "when using an underscore prefix" do
+          it "reports an offense" do
+            expect_offense(<<~RUBY.strip_indent)
+              #{module_or_class} FooService
+                private
+
+                #{module_or_class} InnerService
+                  def self._method
+                  ^^^^^^^^^^^^^^^^ Include a private declaration above the private methods.
+                    nil
+                  end
+
+                  def _method
+                  ^^^^^^^^^^^ Include a private declaration above the private methods.
+                    nil
+                  end
+
+                  private
+                end
+              end
+            RUBY
+          end
+        end
+
+        context "when not using an underscore prefix" do
+          it "does not report an offense" do
+            expect_no_offenses(<<~RUBY.strip_indent)
+              #{module_or_class} FooService
+                private
+
+                #{module_or_class} InnerService
+                  def self.method
+                    nil
+                  end
+
+                  def method
+                    nil
+                  end
+                end
+              end
+            RUBY
+          end
+        end
+      end
+
+      context "when writing a method below the private modifier" do
+        context "when not using an underscore prefix" do
+          it "reports an offense" do
+            expect_offense(<<~RUBY.strip_indent)
+              #{module_or_class} FooService
+                private
+
+                #{module_or_class} InnerService
+                  private
+
+                  def self.method
+                  ^^^^^^^^^^^^^^^ Prefix private method names with an underscore. If method should be public, move it above the private scope.
+                    nil
+                  end
+
+                  def method
+                  ^^^^^^^^^^ Prefix private method names with an underscore. If method should be public, move it above the private scope.
+                    nil
+                  end
+                end
+              end
+            RUBY
+          end
+        end
+
+        context "when using an underscore prefix" do
+          it "does not report an offense" do
+            expect_no_offenses(<<~RUBY.strip_indent)
+              #{module_or_class} FooService
+                private
+
+                #{module_or_class} InnerService
+                  private
+
+                  def self._method
+                    nil
+                  end
+
+                  def _method
+                    nil
+                  end
+                end
+              end
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context "when linting a class" do
+    let(:module_or_class) { "class" }
+
+    it_behaves_like "underscore prefix linting"
+  end
+
+  context "when linting a module" do
+    let(:module_or_class) { "module" }
+
+    it_behaves_like "underscore prefix linting"
+  end
+end


### PR DESCRIPTION
I noticed while writing some code that linting wasn't working. It turns out the underscore prefix rule was broken for modules entirely and for any static methods.

This PR fixes that and adds tests.

<!-- probot = {"487052":{"current_lock":false}} -->

<!-- probot = {"487052":{"current_lock":false,"slack_message_context_CEBE11H25":"1553621031.065300"}} -->