### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.1)
+    root-ruby-style (0.0.2)
       rubocop (= 0.58.2)
 
 GEM
@@ -11,10 +11,10 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     diff-lcs (1.3)
-    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.2)
     method_source (0.9.0)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     pry (0.11.3)
@@ -46,7 +46,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "root-ruby-style"
-  gem.version       = "0.0.1"
+  gem.version       = "0.0.2"
   gem.authors       = ["Root Devs"]
   gem.email         = ["devs@joinroot.com"]
 


### PR DESCRIPTION
This PR increments the version from `0.0.1` to `0.0.2` so that the gem will update when `bundle update root-ruby-style` is run. This is needed because new linter rules were added.

<!-- probot = {"487052":{"current_lock":false,"slack_message_context_CEBE11H25":"1555442049.019100","slack_message_context_CCJ1BMU3E":"1555442053.030500"}} -->