### PR TITLE
Remove stray require

### DIFF
--- a/lib/rubocop/cop/root_cops/retry_on_warning.rb
+++ b/lib/rubocop/cop/root_cops/retry_on_warning.rb
@@ -1,4 +1,3 @@
-require "pry"
 module RuboCop
   module Cop
     module RootCops


### PR DESCRIPTION
This PR removes a stray `require "pry"` that causes exceptions within codebases that don't include pry in the Gemfile.