### PR TITLE
Adds AvoidRubyProf cop to prevent keeping :ruby_prof metadata in spec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-performance
   - rubocop-rspec
+  - ./lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
   - ./lib/rubocop/cop/root_cops/eq_be_eql.rb
   - ./lib/rubocop/cop/root_cops/factories/factory_file_name.rb
   - ./lib/rubocop/cop/root_cops/factories/factory_name.rb

--- a/lib/rubocop/cop/root_cops.rb
+++ b/lib/rubocop/cop/root_cops.rb
@@ -1,5 +1,6 @@
 require "rubocop"
 
+require_relative "root_cops/avoid_ruby_prof"
 require_relative "root_cops/eq_be_eql"
 require_relative "root_cops/factories/factory_file_name"
 require_relative "root_cops/factories/factory_name"

--- a/lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
+++ b/lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RootCops
+      class AvoidRubyProf < Cop
+        ERROR = ":ruby_prof is for local use only and should not be committed."
+        FILE_NAME_MATCHER = /_spec\.rb\z/.freeze
+
+        def_node_matcher :spec_block?, <<~PATTERN
+          (send nil? {:describe :context :it} ...)
+        PATTERN
+
+        def investigate(processed_source)
+          @in_spec_file = processed_source.file_path =~ FILE_NAME_MATCHER
+        end
+
+        def on_sym(node)
+          return unless @in_spec_file && node.value == :ruby_prof && spec_block?(node.parent)
+
+          add_offense(node, :location => :expression, :message => ERROR)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/root_cops/avoid_ruby_prof_spec.rb
+++ b/spec/rubocop/cop/root_cops/avoid_ruby_prof_spec.rb
@@ -1,0 +1,105 @@
+require_relative "../../../spec_helper.rb"
+
+RSpec.describe RuboCop::Cop::RootCops::AvoidRubyProf do
+  subject(:cop) { described_class.new }
+
+  let(:file_path) { "/tmp/avoid_ruby_prof_spec.rb" }
+
+  before do
+    allow_any_instance_of(RuboCop::ProcessedSource).to receive(:file_path).and_return(file_path) # rubocop:disable RSpec/AnyInstance
+  end
+
+  context "when ruby_prof is the only metadata used in a `describe` block's definition" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        describe "a class", :ruby_prof do
+                            ^^^^^^^^^^ :ruby_prof is for local use only and should not be committed.
+          let(:foo) { "bar" }
+
+          context "when tested" do
+            it "asserts some functionality" do
+              expect(foo).to eq("bar")
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when ruby_prof is the only metadata used in a `context` block's definition" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        describe "a class" do
+          let(:foo) { "bar" }
+
+          context "when tested", :ruby_prof do
+                                 ^^^^^^^^^^ :ruby_prof is for local use only and should not be committed.
+            it "asserts some functionality" do
+              expect(foo).to eq("bar")
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when ruby_prof is the only metadata used in an `it` block's definition" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        let(:foo) { "bar" }
+
+        it "asserts some functionality", :ruby_prof do
+                                         ^^^^^^^^^^ :ruby_prof is for local use only and should not be committed.
+          expect(foo).to eq("bar")
+        end
+      RUBY
+    end
+  end
+
+  context "when there is additional metadata used in an `it` block's definition" do
+    it "reports an offense" do
+      expect_offense(<<~RUBY.strip_indent)
+        let(:foo) { "bar" }
+
+        it "asserts some functionality", :foo, :ruby_prof, :bar do
+                                               ^^^^^^^^^^ :ruby_prof is for local use only and should not be committed.
+          expect(foo).to eq("bar")
+        end
+      RUBY
+    end
+  end
+
+  context "when ruby_prof is used in the body of an `it` block" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        it "asserts some functionality" do
+          expect(:ruby_prof).to eq(:ruby_prof)
+        end
+      RUBY
+    end
+  end
+
+  context "when ruby_prof is used elsewhere" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        class Foo
+          def bar
+            :ruby_prof
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when ruby_prof used outside of a spec file" do
+    let(:file_path) { "/tmp/avoid_ruby_prof.rb" }
+
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY.strip_indent)
+        it "asserts some functionality", :ruby_prof do
+          expect(true).to eq(true)
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
To complement https://github.com/Root-App/root-server/pull/12575 this prevents any spec files from being committed with the `:ruby_prof` tag, which would greatly slow down spec running.