### PR TITLE
Don't mix keyword and positional arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-performance
   - rubocop-rspec
   - ./lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
+  - ./lib/rubocop/cop/root_cops/dont_mix_keyword_and_positional_args.rb
   - ./lib/rubocop/cop/root_cops/eq_be_eql.rb
   - ./lib/rubocop/cop/root_cops/factories/factory_file_name.rb
   - ./lib/rubocop/cop/root_cops/factories/factory_name.rb
@@ -163,6 +164,11 @@ Style/WordArray:
 # UnnecessaryAggregateFailures is off by default because it requires extra configuration within the project that uses it
 RootCops/UnnecessaryAggregateFailures:
   Enabled: false
+
+# DontMixKeywordAndPositionalArgs is off by default until it all offenses are fixed
+RootCops/DontMixKeywordAndPositionalArgs:
+  Enabled: false
+
 
 Factories/FactoryFileName:
   Include:

--- a/lib/rubocop/cop/root_cops.rb
+++ b/lib/rubocop/cop/root_cops.rb
@@ -1,6 +1,7 @@
 require "rubocop"
 
 require_relative "root_cops/avoid_ruby_prof"
+require_relative "root_cops/dont_mix_keyword_and_positional_args"
 require_relative "root_cops/eq_be_eql"
 require_relative "root_cops/factories/factory_file_name"
 require_relative "root_cops/factories/factory_name"

--- a/lib/rubocop/cop/root_cops/dont_mix_keyword_and_positional_args.rb
+++ b/lib/rubocop/cop/root_cops/dont_mix_keyword_and_positional_args.rb
@@ -1,0 +1,33 @@
+module RuboCop
+  module Cop
+    module RootCops
+      # Don't Mix keyword ags and position args
+      #
+      # @example
+      #   # bad
+      #   def meth(a, b:); end
+      #   def meth(a, b = 1, c:, d: 3)
+      #
+      #   # good
+      #   def meth(a, b); end
+      #   def meth(a:, b:); end
+      #
+      #   def meth(a, b = 1, c, d = 3)
+      #   def meth(a:, b: 1, c:, d: 3)
+
+      class DontMixKeywordAndPositionalArgs < Cop
+        POSITIONAL_ARG_TYPES = %i[arg optarg restarg].freeze
+        KEYWORD_ARG_TYPES = %i[kwarg kwoptarg kwsplat kwrestarg].freeze
+        ERROR = "Do not mix keyword args and positional args".freeze
+
+        def on_def(node)
+          arguments = node.arguments&.children
+
+          return unless arguments.any? { |a| POSITIONAL_ARG_TYPES.include?(a.type) } && arguments.any? { |a| KEYWORD_ARG_TYPES.include?(a.type) }
+
+          add_offense(node, :location => :expression, :message => ERROR)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/root_cops/dont_mix_keyword_and_positional_args_spec.rb
+++ b/spec/rubocop/cop/root_cops/dont_mix_keyword_and_positional_args_spec.rb
@@ -1,0 +1,52 @@
+require_relative "../../../spec_helper.rb"
+
+RSpec.describe RuboCop::Cop::RootCops::DontMixKeywordAndPositionalArgs do
+  subject(:cop) { described_class.new }
+
+  it "does not report an offense for normal, optional, and rest positional args" do
+    expect_no_offenses(<<~RUBY.strip_indent)
+      def meth(positional, optional = 3, *rest); end
+    RUBY
+  end
+
+  it "does not report an offense for normal, optional, and rest keyword args" do
+    expect_no_offenses(<<~RUBY.strip_indent)
+      def meth(kwarg:, opt_kwarg: 3, **rest_kwarg); end
+    RUBY
+  end
+
+  it "reports an offense when using positional and keyword args (example 1)" do
+    expect_offense(<<~RUBY.strip_indent)
+      def meth(positional, kwarg:); end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix keyword args and positional args
+    RUBY
+  end
+
+  it "reports an offense when using positional and keyword args (example 2)" do
+    expect_offense(<<~RUBY.strip_indent)
+      def meth(opt_positional = 3, opt_kwarg: 3); end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix keyword args and positional args
+    RUBY
+  end
+
+  it "reports an offense when using positional and keyword args (example 3)" do
+    expect_offense(<<~RUBY.strip_indent)
+      def meth(positional, opt_positional = 3, kwarg:); end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix keyword args and positional args
+    RUBY
+  end
+
+  it "reports an offense when using positional and keyword args (example 4)" do
+    expect_offense(<<~RUBY.strip_indent)
+      def meth(positional, opt_positional = 3, kwarg:, opt_kwarg: 5); end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix keyword args and positional args
+    RUBY
+  end
+
+  it "reports an offense when using positional and keyword args (example 5)" do
+    expect_offense(<<~RUBY.strip_indent)
+      def meth(*rest, **rest_kwargs); end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix keyword args and positional args
+    RUBY
+  end
+end


### PR DESCRIPTION
In Ruby version 2.7 there will be warnings that keyword and positional arguments cannot be used in the same method. In ruby version 3.0 this will be forbidden. WIth a rubocop rule, we should be able to find all of the cases where this occurs in order to resolve.