### PR TITLE
Warn against too long retry when queuing to SQS

### DIFF
--- a/lib/rubocop/cop/root_cops/retry_on_warning.rb
+++ b/lib/rubocop/cop/root_cops/retry_on_warning.rb
@@ -2,7 +2,7 @@ module RuboCop
   module Cop
     module RootCops
       class RetryOnWarning < Cop
-        MSG = %(Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning.).freeze
+        MSG = %(Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.).freeze
 
         def on_send(node)
           _receiver, method_name = *node

--- a/spec/rubocop/cop/root_cops/retry_on_warning_spec.rb
+++ b/spec/rubocop/cop/root_cops/retry_on_warning_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RootCops::RetryOnWarning do
   it "reports an offense for retry_on" do
     expect_offense(<<~RUBY.strip_indent)
       retry_on StandardError
-      ^^^^^^^^^^^^^^^^^^^^^^ Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning.
+      ^^^^^^^^^^^^^^^^^^^^^^ Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.
     RUBY
   end
 


### PR DESCRIPTION
If an SQS job is retried with a wait of more than 15 minutes, the job will error out and will not get processed. Adding a note to this regard to the existing warning for `retry_on`.