### PR TITLE
Fix Issue Where Constant Is Already Defined

### DIFF
--- a/spec/rubocop/cop/root_cops/no_tracers_spec.rb
+++ b/spec/rubocop/cop/root_cops/no_tracers_spec.rb
@@ -1,12 +1,7 @@
 RSpec.describe RootCops::NoTracers do
-  OFFENDING_FORMS = [
-    "Tracer.trace_method".freeze,
-    "Tracer.any_method".freeze
-  ].freeze
-
   subject(:cop) { described_class.new }
 
-  OFFENDING_FORMS.each do |offending_form|
+  ["Tracer.trace_method", "Tracer.any_method"].each do |offending_form|
     it_behaves_like "registers an offense", offending_form, described_class::MSG
   end
 end


### PR DESCRIPTION
Fixes the following warning:

```
/Users/kyledecot/code/root-ruby-style/spec/rubocop/cop/root_cops/no_tracers_spec.rb:4: warning: already initialized constant OFFENDING_FORMS
/Users/kyledecot/code/root-ruby-style/spec/rubocop/cop/root_cops/eq_be_eql_spec.rb:4: warning: previous definition of OFFENDING_FORMS was here
```