### PR TITLE
Ignores system name in factory names.

### DIFF
--- a/lib/rubocop/cop/root_cops/factories/factory_name.rb
+++ b/lib/rubocop/cop/root_cops/factories/factory_name.rb
@@ -6,8 +6,13 @@ module RuboCop
     module RootCops
       module Factories
         class FactoryName < Cop
+          SYSTEM_IN_PATH = %r{systems/([^/]+)/}.freeze
+
           def investigate(processed_source)
             file_path = processed_source.buffer.name
+            system_name_match = file_path.match(SYSTEM_IN_PATH)
+
+            @system_name = system_name_match && system_name_match[1]
             @base_file_name = File.basename(file_path, ".rb")
             @base_file_name_body = _generate_body(@base_file_name)
             @base_file_name_last_word = @base_file_name.split("_").last
@@ -22,6 +27,8 @@ module RuboCop
 
             factory_symbol_name = *node.arguments[0]
             factory_name_array = factory_symbol_name[0].id2name.split("__")
+            factory_name_array.shift if factory_name_array.size > 1 && factory_name_array[0] == @system_name
+
             factory_name = factory_name_array.first
             factory_name_body = _generate_body(factory_name)
             factory_name_last_word = factory_name.split("_").last

--- a/spec/rubocop/cop/root_cops/factories/factory_name_spec.rb
+++ b/spec/rubocop/cop/root_cops/factories/factory_name_spec.rb
@@ -2,12 +2,10 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
   subject(:cop) { described_class.new }
 
   context "when the factory file name is incorrect" do
-    before do
-      allow(File).to receive(:basename).and_return("user_billing")
-    end
+    let(:factory_file_path) { "/code/server/systems/sample/spec/factories/user_billing.rb" }
 
     it "skips all factory name checks and registers no offenses" do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY, factory_file_path)
         FactoryBot.define do
           factory :user_billing do
             ref { "new-branch" }
@@ -45,13 +43,11 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
   context "when the factory file name is correct" do
     context "when the last word in the file name is pluralized" do
-      before do
-        allow(File).to receive(:basename).and_return("user_billings")
-      end
+      let(:factory_file_path) { "/code/server/systems/sample/spec/factories/user_billings.rb" }
 
       context "and the factory name equals the file name" do
         it "does not register an offense" do
-          expect_no_offenses(<<-RUBY)
+          expect_no_offenses(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :user_billings do
                 ref { "new-branch" }
@@ -63,9 +59,9 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
         end
       end
 
-      context "and the factory name equals the singular version of the file name." do
+      context "and the factory name equals the singular version of the file name" do
         it "does not register an offense" do
-          expect_no_offenses(<<-RUBY)
+          expect_no_offenses(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :user_billing do
                 ref { "new-branch" }
@@ -75,11 +71,25 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
             end
           RUBY
         end
+
+        context "and the system name equals the factory name" do
+          let(:factory_file_path) { "/code/server/systems/policy/spec/factories/policies.rb" }
+
+          it "does not register an offense" do
+            expect_no_offenses(<<~RUBY, factory_file_path)
+              FactoryBot.define do
+                factory :policy do
+                  policy_number { "12345AK" }
+                end
+              end
+            RUBY
+          end
+        end
       end
 
       context "and the factory name does not equal the file name or the singular version of the file name" do
         it "registers an offense" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :payment do
               ^^^^^^^^^^^^^^^^ Factory should be in own file or be named the singular form of the file name. OR group closely related factories in the same file and prefix their names with 'user_billings__'.
@@ -106,7 +116,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and the factory uses the file name as a prefix" do
         it "does not register an offense" do
-          expect_no_offenses(<<-RUBY)
+          expect_no_offenses(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :user_billings__payment do
                 ref { "new-branch" }
@@ -120,7 +130,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and the factory name uses an incorrect prefix" do
         it "registers an offense" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :user_billing__payment do
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Factory name uses incorrect prefix, should be 'user_billings__payment'.
@@ -145,9 +155,37 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
         end
       end
 
+      context "and the factory uses the system name as a prefix" do
+        it "does not register an offense" do
+          expect_no_offenses(<<~RUBY, factory_file_path)
+            FactoryBot.define do
+              factory :sample__user_billing do
+                ref { "new-branch" }
+                ref_type { "branch" }
+                master_branch { "master" }
+              end
+            end
+          RUBY
+        end
+
+        context "and the factory uses the file name as a prefix" do
+          it "does not register an offense" do
+            expect_no_offenses(<<~RUBY, factory_file_path)
+              FactoryBot.define do
+                factory :sample__user_billings__payment do
+                  ref { "new-branch" }
+                  ref_type { "branch" }
+                  master_branch { "master" }
+                end
+              end
+            RUBY
+          end
+        end
+      end
+
       context "and there are multiple offenses" do
         it "registers all the offenses" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :user_billing do
                 ref { "new-branch" }
@@ -187,13 +225,11 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
     end
 
     context "when the last word in the file name is an invariant noun" do
-      before do
-        allow(File).to receive(:basename).and_return("billing_fish")
-      end
+      let(:factory_file_path) { "/code/server/systems/sample/spec/factories/billing_fish.rb" }
 
       context "and the factory name equals the file name" do
         it "does not register an offense" do
-          expect_no_offenses(<<-RUBY)
+          expect_no_offenses(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :billing_fish do
                 ref { "new-branch" }
@@ -207,7 +243,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and the factory name does not equal the the file name" do
         it "registers an offense" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :payment do
               ^^^^^^^^^^^^^^^^ Factory should be in own file or be named the singular form of the file name. OR group closely related factories in the same file and prefix their names with 'billing_fish__'.
@@ -228,7 +264,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and the factory uses the file name as a prefix" do
         it "does not register an offense" do
-          expect_no_offenses(<<-RUBY)
+          expect_no_offenses(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :billing_fish__payment do
                 ref { "new-branch" }
@@ -242,7 +278,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and the factory name uses an incorrect prefix" do
         it "registers an offense" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :billing__payment do
               ^^^^^^^^^^^^^^^^^^^^^^^^^ Factory name uses incorrect prefix, should be 'billing_fish__payment'.
@@ -263,7 +299,7 @@ RSpec.describe RuboCop::Cop::RootCops::Factories::FactoryName do
 
       context "and there are multiple offenses" do
         it "registers all the offenses" do
-          expect_offense(<<-RUBY)
+          expect_offense(<<~RUBY, factory_file_path)
             FactoryBot.define do
               factory :billing_fish do
                 ref { "new-branch" }


### PR DESCRIPTION
For the types defined in system interfaces, we've landed on a format of:

```ruby
# systems/policy/policy_system/spec/factories/drivers.rb
factory :policy__driver ...

# or with additional underscores, though we should prefer traits when possible
factory :policy__drivers__with_special_thing
```