### PR TITLE
`try` doesn't always refer to the ActiveSupport version

### DIFF
--- a/lib/rubocop/cop/root_cops/use_lonely_operator.rb
+++ b/lib/rubocop/cop/root_cops/use_lonely_operator.rb
@@ -6,7 +6,7 @@ module RuboCop
 
         def on_send(node)
           _receiver, method_name = *node
-          if %i[try try!].include?(method_name)
+          if %i[try try!].include?(method_name) && node.arguments?
             add_offense(node, :location => :expression, :message => MSG)
           end
         end

--- a/spec/rubocop/cop/root_cops/use_lonely_operator_spec.rb
+++ b/spec/rubocop/cop/root_cops/use_lonely_operator_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe RuboCop::Cop::RootCops::UseLonelyOperator do
       foo.bar
     RUBY
   end
+
+  it "doesn't report an offense for uses of try that are not eligible for lonely operator" do
+    expect_no_offenses(<<~RUBY)
+      experiment.try do
+        some_code_to_try
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Specifically, every time we introduce an `EngineeringExperiment` we have to
disable this cop because the syntax is:

```ruby
experiment.use do
  # control group
end

experiment.try do
  # experimental group
end
```