### PR TITLE
retry_on_warning offers help with before_retry

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -188,3 +188,7 @@ Factories/FactoryFileName:
 Factories/FactoryName:
   Include:
     - '**/spec/factories/*.rb'
+
+RootCops/RetryOnWarning:
+  Include:
+    - '**_job.rb'

--- a/lib/rubocop/cop/root_cops/retry_on_warning.rb
+++ b/lib/rubocop/cop/root_cops/retry_on_warning.rb
@@ -1,15 +1,58 @@
 module RuboCop
   module Cop
     module RootCops
+      # define `before_retry` when using `retry_on`
+      #
+      # @example
+      #   # bad
+      #   class RetryableJob
+      #     retry_on StandardError
+      #     def perform(customer_id:)
+      #       Charge_customer(customer_id)
+      #     end
+      #   end
+      #
+      #   # good
+      #   class RetryableJob
+      #     retry_on StandardError
+      #     def perform(customer_id:)
+      #       charge_customer(customer_id)
+      #     end
+      #     def before_retry(customer_id:)
+      #       raise if already_charged(customer_id)
+      #     end
+      #   end
+
       class RetryOnWarning < Cop
-        MSG = %(Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.).freeze
+        MSG = %(When using "retry_on", ensure the job is idempotent and define a 'before_retry' to handle side effects or preconditions. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.).freeze
 
-        def on_send(node)
-          _receiver, method_name = *node
+        def on_class(node)
+          class_name = node.to_a[0].to_a[1]
+          return unless class_name.to_s.end_with?("Job")
 
-          if method_name == :retry_on
+          if _includes_retry_on?(node) && (_missing_before_retry?(node) || _retry_args_mismatch?(node))
             add_offense(node, :location => :expression, :message => MSG)
           end
+        end
+
+        private
+
+        def _includes_retry_on?(node)
+          send_descendants = node.descendants.select(&:send_type?)
+          send_descendants.any? { |d| d.to_a[1] == :retry_on }
+        end
+
+        def _missing_before_retry?(node)
+          begin_descendants = node.descendants.select(&:begin_type?)
+          begin_descendants.none? { |d| d.to_a[0] == :before_retry }
+        end
+
+        def _retry_args_mismatch?(node)
+          begin_descendants = node.descendants.select(&:begin_type?)
+          perform_def = begin_descendants.detect? { |d| d.to_a[0] == :perform }
+          retry_def = begin_descendants.detect? { |d| d.to_a[0] == :before_retry }
+
+          retry_def.to_a[1] != perform_def.to_a[1]
         end
       end
     end

--- a/spec/rubocop/cop/root_cops/retry_on_warning_spec.rb
+++ b/spec/rubocop/cop/root_cops/retry_on_warning_spec.rb
@@ -3,14 +3,44 @@ RSpec.describe RuboCop::Cop::RootCops::RetryOnWarning do
 
   it "reports an offense for retry_on" do
     expect_offense(<<~RUBY)
+      class RetryableJob
+      ^^^^^^^^^^^^^^^^^^ When using "retry_on", ensure the job is idempotent and define a 'before_retry' to handle side effects or preconditions. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.
+        retry_on StandardError
+      end
+    RUBY
+  end
+
+  it "doesn't report an offense if before_retry is implemented" do
+    expect_no_offenses(<<~RUBY)
+      class RetryableJob
+        retry_off StandardError
+        def perform(param_1:); end
+        def before_retry(param_1:); end
+      end
+    RUBY
+  end
+
+  it "does report an offense if before_retry has a different method signature than perform" do
+    expect_no_offenses(<<~RUBY)
+      class AttemptBillingForAccountJob < ResqueJob
+        retry_off StandardError
+        def perform(param_1:); end
+        def before_retry(param_2:); end
+      end
+    RUBY
+  end
+
+  it "doesn't report an offense outside of Job classes" do
+    expect_no_offenses(<<~RUBY)
       retry_on StandardError
-      ^^^^^^^^^^^^^^^^^^^^^^ Use care when implementing "retry_on". Look for side effects on the retried job before disabling warning. NOTE: Jobs running on SQS cannot wait longer than 15 minutes for retry.
     RUBY
   end
 
   it "doesn't report an offense for methods other than retry_on" do
     expect_no_offenses(<<~RUBY)
-      retry_off StandardError
+      class RetryableJob
+        retry_off StandardError
+      end
     RUBY
   end
 end


### PR DESCRIPTION
Updating this cop to correspond to a new pattern in retryable jobs https://github.com/Root-App/root-monorepo/pull/27989

We now have a path to eliminate lint warnings, instead of permanent ignores!

This modifies the rule to execute only once on each class definition, and only executes on files named `*_job.rb` This should help with 

- Small performance boost
- jobs that use automatic retries need to ignore/address the rule only once (not one per retry statement)

This means in the corresponding monorepo PR to include this rule, we'll need to update ~100 job files to move the "`# ignore`" to the class definition. 