### PR TITLE
Adds PricingBackfillQueueConcern to the list of mixins that provide queue_as functionality

### DIFF
--- a/lib/rubocop/cop/root_cops/job_has_queue.rb
+++ b/lib/rubocop/cop/root_cops/job_has_queue.rb
@@ -3,7 +3,7 @@ module RuboCop
     module RootCops
       class JobHasQueue < Cop
         MESSAGE = "Configure the job to run in a specific queue using queue_as, sharded_queue_as or a whitelisted mixin.".freeze
-        MIXIN_WHITELIST = %i[LookupQueueConcern NewBusinessQuoteCreationQueueConcern RatesQueueConcern].freeze
+        MIXIN_WHITELIST = %i[LookupQueueConcern NewBusinessQuoteCreationQueueConcern PricingBackfillQueueConcern RatesQueueConcern].freeze
         QUEUEING_OPTIONS = %i[queue_as sharded_queue_as].freeze
 
         def on_class(node)


### PR DESCRIPTION
This Concern is being added in https://github.com/Root-App/root-monorepo/pull/28466. However, without this rule modification, actually using it in a job will result in a linting error as Rubocop won't be able to tell that the new mixin provides `queue_as` functionality and therefore the job does not need to define that itself.