### PR TITLE
Allow multiple options for parent class

### DIFF
--- a/spec/rubocop/cop/root_cops/must_inherit_spec.rb
+++ b/spec/rubocop/cop/root_cops/must_inherit_spec.rb
@@ -119,4 +119,60 @@ RSpec.describe RuboCop::Cop::RootCops::MustInherit, :config do
       RUBY
     end
   end
+
+  context "with multiple parent class options configured" do
+    let(:cop_config) do
+      {
+        "Mapping" => [
+          {
+            "Dir" => "systems/**/app/jobs",
+            "ParentClass" => ["MyJob", "MySpecialJob"]
+          }
+        ]
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:expand_path).and_return("/home/me/systems/cops/app/jobs/namespace/greeting.rb")
+    end
+
+    it "reports an offense when the class doesn't inherit from configured class" do
+      expect_offense(<<~RUBY)
+        module Namespace
+          class GreetingsJob < ApplicationJob
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Classes in this directory must inherit from MyJob or MySpecialJob
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when the class doesn't inherit from anything" do
+      expect_offense(<<~RUBY)
+        class GreetingsJob
+        ^^^^^^^^^^^^^^^^^^ Classes in this directory must inherit from MyJob or MySpecialJob
+        end
+      RUBY
+    end
+
+    it "reports no offenses when the class is the parent class definition" do
+      expect_no_offenses(<<~RUBY)
+        class MyJob < ApplicationJob
+        end
+      RUBY
+    end
+
+    it "reports no offense when specifies the proper class" do
+      expect_no_offenses(<<~RUBY)
+        class GreetingsJob < MyJob
+        end
+      RUBY
+    end
+
+    it "reports no offense when specifies the alternate class" do
+      expect_no_offenses(<<~RUBY)
+        class GreetingsJob < MySpecialJob
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
I want to be able to enforce that AR models in the claims system inherit from ClaimsRecord, but some of them need to inherit from PaperTrail::ClaimsVersion. This change makes it possible to specify a list of valid superclasses for a given directory