### PR TITLE
Detect namespaced constants properly

### DIFF
--- a/lib/rubocop/cop/root_cops/must_include.rb
+++ b/lib/rubocop/cop/root_cops/must_include.rb
@@ -44,8 +44,7 @@ module RuboCop
         end
 
         def_node_matcher :find_module_inclusion, <<~PATTERN
-          (send nil? :include
-              (const _ $_module_name))
+          (send nil? :include $_module_node)
         PATTERN
 
         def on_class(node)
@@ -56,8 +55,8 @@ module RuboCop
         def on_send(node)
           return unless search_for_inclusion? && !@proper_module_is_included
 
-          find_module_inclusion(node) do |module_name|
-            @proper_module_is_included ||= module_name.to_s == @module_to_include
+          find_module_inclusion(node) do |module_node|
+            @proper_module_is_included ||= module_node.const_name == @module_to_include
           end
         end
 

--- a/lib/rubocop/cop/root_cops/must_inherit.rb
+++ b/lib/rubocop/cop/root_cops/must_inherit.rb
@@ -35,20 +35,13 @@ module RuboCop
           @source_file_path = self.class.expand_path(processed_source.buffer.name)
         end
 
-        def_node_matcher :find_class_inheritance, <<~PATTERN
-          (class
-           (const _ $_child)
-           {(const _ $_parent) $_noparent}
-           _)
-        PATTERN
-
         def on_class(node)
           return unless (class_options = class_options_for_current_file)
 
-          find_class_inheritance(node) do |class_name, superclass_name|
-            unless class_name_match?(class_name, superclass_name, class_options)
-              add_offense(node, :location => :expression, :message => "Classes in this directory must inherit from #{class_options_to_s(class_options)}")
-            end
+          class_name = node.identifier.const_name
+          superclass_name = node.parent_class&.const_name
+          unless class_name_match?(class_name, superclass_name, class_options)
+            add_offense(node, :location => :expression, :message => "Classes in this directory must inherit from #{class_options_to_s(class_options)}")
           end
         end
 


### PR DESCRIPTION
When requiring parent class or included module, we would like to be able to specify namespaced constants.