### PR TITLE
Remove cop configurations that won't work with include paths

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,14 +187,6 @@ RootCops/UnnecessaryAggregateFailures:
 RootCops/MustInherit:
   Enabled: false
 
-RootCops/Factories/FactoryFileName:
-  Include:
-    - '**/spec/factories/*.rb'
-
-RootCops/Factories/FactoryName:
-  Include:
-    - '**/spec/factories/*.rb'
-
 RSpec/FactoryBot/CreateList:
   Enabled: false
 


### PR DESCRIPTION
Strange one here; a "[bugfix](https://github.com/rubocop/rubocop/pull/9706)" that was meant to fix pathing broke it for including it from a gem. Basically, it would create an entry in the config, but keep the path from the gem, and thus would always use the globbing pattern from include or exclude with the path of the gem smashed in front, making that pattern useless in the consumer of the gem. Overwriting the pattern in the consumer does nothing to change the path issue, it keeps the path from the first definition (and it loads from gem includes first, naturally.)

So, we're moving these cops' entries into monorepo.

It's all very annoying.