### PR TITLE
Update to be more opinionated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -207,3 +207,111 @@ Gemspec/RequiredRubyVersion:
 
 Style/SlicingWithRange:
   Enabled: false
+
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+
+Layout/LineEndStringConcatenationIndentation: # (new in 1.18)
+  Enabled: false
+
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: false
+
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: false
+
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: false
+
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: false
+
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: false
+
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: false
+
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: false
+
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: false
+
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: false
+
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: false
+
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: false
+
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: false
+
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+
+Naming/InclusiveLanguage: # (new in 1.18)
+  Enabled: false
+
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: false
+
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: false
+
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: false
+
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: false
+
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+
+Style/HashExcept: # (new in 1.7)
+  Enabled: false
+
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+
+Style/InPatternThen: # (new in 1.16)
+  Enabled: false
+
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: false
+
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: false
+
+Style/NilLambda: # (new in 1.3)
+  Enabled: false
+
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: false
+
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: false
+
+Style/StringChars: # (new in 1.12)
+  Enabled: false
+
+Style/SwapValues: # (new in 1.1)
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.5)
+    root-ruby-style (0.0.6)
       activesupport (>= 5.0, < 7.x)
       rubocop (~> 1.18.4)
       rubocop-performance (= 1.5.2)
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -22,12 +22,12 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.9)
     diff-lcs (1.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
     minitest (5.14.4)
-    parallel (1.20.1)
-    parser (3.0.2.0)
+    parallel (1.21.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -61,7 +61,7 @@ GEM
       rubocop-ast (>= 1.8.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.9.1)
+    rubocop-ast (1.14.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
@@ -74,8 +74,8 @@ GEM
     ruby-progressbar (1.11.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.0.0)
-    zeitwerk (2.4.2)
+    unicode-display_width (2.1.0)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "root-ruby-style"
-  gem.version       = "0.0.5"
+  gem.version       = "0.0.6"
   gem.authors       = ["Root Devs"]
   gem.email         = ["devs@joinroot.com"]
 


### PR DESCRIPTION
This is a change that will remove the warnings about unconfigured rules for repos that didn't set up the rules in their rubocop.yml. It also turns on a few, more conservative rules. 

When we do the Ruby 3 targeting version, I'm planning to turn on more of these as well.

The associated changes in monorepo: https://github.com/Root-App/root-monorepo/pull/46307
And in rooter-bot: https://github.com/Root-App/rooter-bot-rails/pull/1054