### PR TITLE
Remove 'try' from UseLonelyOperator cop, since 'try' is actually useful

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.7)
+    root-ruby-style (0.0.8)
       activesupport (>= 5.0, < 7.x)
       rubocop (~> 1.18.4)
       rubocop-performance (= 1.5.2)
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.5)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -20,14 +20,14 @@ GEM
     ast (2.4.2)
     byebug (11.0.1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.0)
     diff-lcs (1.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.15.0)
-    parallel (1.21.0)
-    parser (3.1.1.0)
+    minitest (5.17.0)
+    parallel (1.22.1)
+    parser (3.2.1.0)
       ast (~> 2.4.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -35,9 +35,9 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    rack (2.2.3)
+    rack (3.0.4.1)
     rainbow (3.1.1)
-    regexp_parser (2.2.1)
+    regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -61,8 +61,8 @@ GEM
       rubocop-ast (>= 1.8.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
-      parser (>= 3.1.1.0)
+    rubocop-ast (1.26.0)
+      parser (>= 3.2.1.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)
@@ -72,10 +72,10 @@ GEM
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
-    zeitwerk (2.5.4)
+    unicode-display_width (2.4.2)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby

--- a/lib/rubocop/cop/root_cops/use_lonely_operator.rb
+++ b/lib/rubocop/cop/root_cops/use_lonely_operator.rb
@@ -2,11 +2,12 @@ module RuboCop
   module Cop
     module RootCops
       class UseLonelyOperator < Cop
-        MSG = "Use the lonely operator foo&.bar instead of foo.try(:bar)".freeze
+        MSG = "Use the lonely operator foo&.bar instead of foo.try!(:bar)".freeze
 
         def on_send(node)
           _receiver, method_name = *node
-          if %i[try try!].include?(method_name) && node.arguments?
+
+          if method_name == :try! && node.arguments?
             add_offense(node, :location => :expression, :message => MSG)
           end
         end

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "root-ruby-style"
-  gem.version       = "0.0.7"
+  gem.version       = "0.0.8"
   gem.authors       = ["Root Devs"]
   gem.email         = ["devs@joinroot.com"]
 

--- a/spec/rubocop/cop/root_cops/use_lonely_operator_spec.rb
+++ b/spec/rubocop/cop/root_cops/use_lonely_operator_spec.rb
@@ -1,29 +1,28 @@
 RSpec.describe RuboCop::Cop::RootCops::UseLonelyOperator do
   subject(:cop) { described_class.new }
 
-  it "reports an offense for try" do
-    expect_offense(<<~RUBY)
-      foo.try(:to_s)
-      ^^^^^^^^^^^^^^ Use the lonely operator foo&.bar instead of foo.try(:bar)
-    RUBY
-  end
-
   it "reports an offense for try!" do
     expect_offense(<<~RUBY)
       foo.try!(:to_s)
-      ^^^^^^^^^^^^^^^ Use the lonely operator foo&.bar instead of foo.try(:bar)
+      ^^^^^^^^^^^^^^^ Use the lonely operator foo&.bar instead of foo.try!(:bar)
     RUBY
   end
 
-  it "doesn't report an offense for methods other than try" do
+  it "doesn't report an offense for methods other than try!" do
     expect_no_offenses(<<~RUBY)
       foo.bar
     RUBY
   end
 
-  it "doesn't report an offense for uses of try that are not eligible for lonely operator" do
+  it "doesn't report an offense for uses of try" do
     expect_no_offenses(<<~RUBY)
-      experiment.try do
+      experiment.try(:to_s)
+    RUBY
+  end
+
+  it "doesn't report an offense for uses of try! that are not eligible for lonely operator" do
+    expect_no_offenses(<<~RUBY)
+      experiment.try! do
         some_code_to_try
       end
     RUBY


### PR DESCRIPTION
## Background
This PR discussion: https://github.com/Root-App/root-monorepo/pull/55308#discussion_r1109983067

## Problem
Whenever we wanna use `try` to simplify something like:

```rb
something.respond_to?(:some_method) && something.some_method
```

to:

```rb
something.try(:some_method)
```

we have to ignore `RootCops/UseLonelyOperator`.

I think this cop is useful for something like `try!` ([doc](https://apidock.com/rails/v5.2.3/Object/try%21)), which appears to be 1:1 with `something&.some_method`; however, `try` ([doc](https://apidock.com/rails/Object/try)) is useful because of its additional `respond_to?` check. This difference appears to have been introduced in Rails 4.

From the `try` [doc](https://apidock.com/rails/Object/try):

> Invokes the public method whose name goes as first argument just like public_send does, except that if the receiver does not respond to it the call returns nil rather than raising an exception.

From the `try!` [doc](https://apidock.com/rails/v5.2.3/Object/try%21):

> Same as #try, but raises a [NoMethodError](https://apidock.com/ruby/NoMethodError) exception if the receiver is not nil and does not implement the tried method.

## Solution
Update `RootCops/UseLonelyOperator` to only check for usage of `try!` instead of also `try`, so we no longer have to ignore this cop for the use-case mentioned above.