### PR TITLE
Switch root-ruby-style pipeline to buildkite v6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 ---
 steps:
   - name: ":rubocop:"
+    agents:
+    - "queue=default-v6"
     timeout_in_minutes: 5
     command: bundle exec rubocop
     plugins:
@@ -9,6 +11,8 @@ steps:
         config: docker-compose.buildkite.yml
 
   - name: ":rspec:"
+    agents:
+    - "queue=default-v6"
     timeout_in_minutes: 5
     command: bundle exec rspec .
     plugins:
@@ -17,6 +21,8 @@ steps:
         config: docker-compose.buildkite.yml
 
   - name: "Ensure gem version"
+    agents:
+    - "queue=default-v6"
     timeout_in_minutes: 5
     command: .buildkite/ensure_package_version
     plugins:
@@ -27,6 +33,8 @@ steps:
   - wait
 
   - name: ":artifactory: Publish gem"
+    agents:
+    - "queue=default-v6"
     timeout_in_minutes: 5
     command: .buildkite/publish
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     timeout_in_minutes: 5
     command: bundle exec rubocop
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v4.16.1:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -16,7 +16,7 @@ steps:
     timeout_in_minutes: 5
     command: bundle exec rspec .
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v4.16.1:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -26,7 +26,7 @@ steps:
     timeout_in_minutes: 5
     command: .buildkite/ensure_package_version
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v4.16.1:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -38,7 +38,7 @@ steps:
     timeout_in_minutes: 5
     command: .buildkite/publish
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v4.16.1:
         run: app
         config: docker-compose.buildkite.yml
         env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     timeout_in_minutes: 5
     command: bundle exec rubocop
     plugins:
-      docker-compose#v4.16.1:
+      docker-compose#v4.16.0:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -16,7 +16,7 @@ steps:
     timeout_in_minutes: 5
     command: bundle exec rspec .
     plugins:
-      docker-compose#v4.16.1:
+      docker-compose#v4.16.0:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -26,7 +26,7 @@ steps:
     timeout_in_minutes: 5
     command: .buildkite/ensure_package_version
     plugins:
-      docker-compose#v4.16.1:
+      docker-compose#v4.16.0:
         run: app
         config: docker-compose.buildkite.yml
 
@@ -38,7 +38,7 @@ steps:
     timeout_in_minutes: 5
     command: .buildkite/publish
     plugins:
-      docker-compose#v4.16.1:
+      docker-compose#v4.16.0:
         run: app
         config: docker-compose.buildkite.yml
         env:


### PR DESCRIPTION
Story : 
https://app.shortcut.com/joinroot/story/274435/migrate-root-ruby-style-pipeline?vc_group_by=day&ct_workflow=all&cf_workflow=500267001

What : 
Switch pipeline to buildkite v6