### PR TITLE
Stop enforcing hash rockets in our style repo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,9 +137,9 @@ Style/FloatDivision:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# use 1.8 style hashes
+# Allow use of 1.8 and 1.9 style hashes, but not both in the same hash
 Style/HashSyntax:
-  EnforcedStyle: hash_rockets
+  EnforcedStyle: no_mixed_keys
 
 Style/HashEachMethods:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.11)
+    root-ruby-style (0.0.12)
       activesupport (>= 5.0, < 8)
       rubocop (> 1.60)
       rubocop-performance (= 1.5.2)
@@ -31,12 +31,12 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
-    minitest (5.22.2)
+    minitest (5.22.3)
     mutex_m (0.2.0)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -77,8 +77,8 @@ GEM
       rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = "root-ruby-style"
-  gem.version = "0.0.11"
+  gem.version = "0.0.12"
   gem.authors = ["Root Devs"]
   gem.email = ["devs@joinroot.com"]
 


### PR DESCRIPTION
## Background
[Related Slack thread](https://joinroot.slack.com/archives/C07783J1FAL/p1727877950567249)

## Problem
We currently strictly enforce that all Ruby hashes use the hash rocket notation.

e.g.
```rb
{
  :some_key => "value",
  "some other key" => 12
}
```

But if we don't enforce this, is it really a big deal? Yeah, we want consistency, but does it _really_ matter if we end up with hashes which look something like the following?

```rb
dynamic_key = :something

{
  :selected => true,
  dynamic_key => "value",
  "other_key" => 78
}

some_key = "some string"

{
  some_key:,
  selected: true,
  "other_key": 78
}
```

## Solution
Leave it up to us to decide when we wanna use hash rockets and when not to use hash rockets, and remove the strict enforcement.

This is just gonna affect this repo, but maybe this is a good chance to discuss this further!