### PR TITLE
Update RuboCop Rails dependency to prevent warning messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (>= 5.0, < 8)
       rubocop (> 1.60)
       rubocop-performance (= 1.5.2)
-      rubocop-rails (~> 2.5.0)
+      rubocop-rails (~> 2.27.0)
       rubocop-rspec (~> 1.38.1)
 
 GEM
@@ -83,10 +83,11 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.5.2)
-      activesupport
+    rubocop-rails (2.27.0)
+      activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.72.0)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.14)
+    root-ruby-style (0.0.15)
       activesupport (>= 5.0, < 8)
       rubocop (> 1.60)
       rubocop-performance (= 1.5.2)

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = "root-ruby-style"
-  gem.version = "0.0.14"
+  gem.version = "0.0.15"
   gem.authors = ["Root Devs"]
   gem.email = ["devs@joinroot.com"]
 

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activesupport", ">= 5.0", "< 8"
   gem.add_runtime_dependency "rubocop", "> 1.60"
   gem.add_runtime_dependency "rubocop-performance", "1.5.2"
-  gem.add_runtime_dependency "rubocop-rails", "~> 2.5.0"
+  gem.add_runtime_dependency "rubocop-rails", "~> 2.27.0"
   gem.add_runtime_dependency "rubocop-rspec", "~> 1.38.1"
 
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
## Notes
- This will NOT go live in root-server until we update root-server to use this new gem version (0.0.15)

---

## Problem
Any time I try to run `rubocop`, I see the following warnings:
<img width="956" alt="Screenshot 2024-12-20 at 7 52 43 PM" src="https://github.com/user-attachments/assets/d6ead35b-6e9c-458f-ada3-c053a2638c5e" />


This isn't hurting anything, but I noticed that it was a relatively easy fix if we just update our RuboCop Rails dependency to at _least_ `v2.9`.

## Solution
Update our RuboCop Rails dependency to the newest version found when running `bundle outdated`: `v2.27.0`