### PR TITLE
Require JSON-style hashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,9 +137,8 @@ Style/FloatDivision:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Allow use of 1.8 and 1.9 style hashes, but not both in the same hash
 Style/HashSyntax:
-  EnforcedStyle: no_mixed_keys
+  EnforcedStyle: ruby19
   EnforcedShorthandSyntax: always
 
 Style/HashEachMethods:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.13)
+    root-ruby-style (0.0.14)
       activesupport (>= 5.0, < 8)
       rubocop (> 1.60)
       rubocop-performance (= 1.5.2)

--- a/lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
+++ b/lib/rubocop/cop/root_cops/avoid_ruby_prof.rb
@@ -18,7 +18,7 @@ module RuboCop
         def on_sym(node)
           return unless @in_spec_file && node.value == :ruby_prof && spec_block?(node.parent)
 
-          add_offense(node, :location => :expression, :message => ERROR)
+          add_offense(node, location: :expression, message: ERROR)
         end
       end
     end

--- a/lib/rubocop/cop/root_cops/envvar_assignment.rb
+++ b/lib/rubocop/cop/root_cops/envvar_assignment.rb
@@ -17,7 +17,7 @@ module RuboCop
           return if value.nil?
           return if @is_initializer_file
 
-          add_offense(node, :location => :expression, :message => MSG) if envvar_assignment?(value)
+          add_offense(node, location: :expression, message: MSG) if envvar_assignment?(value)
         end
 
         def on_or_asgn(node)
@@ -26,7 +26,7 @@ module RuboCop
           return unless lhs&.casgn_type?
           return if @is_initializer_file
 
-          add_offense(node, :location => :expression, :message => MSG) if envvar_assignment?(value)
+          add_offense(node, location: :expression, message: MSG) if envvar_assignment?(value)
         end
       end
     end

--- a/lib/rubocop/cop/root_cops/eq_be_eql.rb
+++ b/lib/rubocop/cop/root_cops/eq_be_eql.rb
@@ -19,11 +19,11 @@ module RootCops
 
     def on_send(node)
       be_or_eql(node) do |offending_node|
-        add_offense(offending_node, :location => :selector)
+        add_offense(offending_node, location: :selector)
       end
 
       be_true_false_nil(node) do |offending_node|
-        add_offense(offending_node, :location => :selector)
+        add_offense(offending_node, location: :selector)
       end
     end
   end

--- a/lib/rubocop/cop/root_cops/factories/factory_file_name.rb
+++ b/lib/rubocop/cop/root_cops/factories/factory_file_name.rb
@@ -19,9 +19,9 @@ module RuboCop
             if receiver_name == :FactoryBot && method_name == :define && Helpers::Factories.file_name_has_error?(@base_file_name)
               add_offense(
                 node,
-                :location => :expression,
-                :severity => :fatal,
-                :message => "Factory file name should be plural (#{@base_file_name.pluralize})."
+                location: :expression,
+                severity: :fatal,
+                message: "Factory file name should be plural (#{@base_file_name.pluralize})."
               )
             end
           end

--- a/lib/rubocop/cop/root_cops/factories/factory_name.rb
+++ b/lib/rubocop/cop/root_cops/factories/factory_name.rb
@@ -37,16 +37,16 @@ module RuboCop
               if factory_name_array[0] != @base_file_name
                 add_offense(
                   node,
-                  :location => :expression,
-                  :message => "Factory name uses incorrect prefix, should be '#{@base_file_name}__#{factory_name_array[1]}'."
+                  location: :expression,
+                  message: "Factory name uses incorrect prefix, should be '#{@base_file_name}__#{factory_name_array[1]}'."
                 )
               end
 
             elsif (factory_name_body != @base_file_name_body) || (factory_name_last_word.pluralize != @base_file_name_last_word)
               add_offense(
                 node,
-                :location => :expression,
-                :message => "Factory should be in own file or be named the singular form of the file name. OR group closely related factories in the same file and prefix their names with '#{@base_file_name}__'."
+                location: :expression,
+                message: "Factory should be in own file or be named the singular form of the file name. OR group closely related factories in the same file and prefix their names with '#{@base_file_name}__'."
               )
             end
           end

--- a/lib/rubocop/cop/root_cops/job_has_queue.rb
+++ b/lib/rubocop/cop/root_cops/job_has_queue.rb
@@ -12,7 +12,7 @@ module RuboCop
 
           send_descendants = node.descendants.select(&:send_type?)
           unless send_descendants.any? { |d| QUEUEING_OPTIONS.include?(d.to_a[1]) || _whitelisted_mixin?(d) }
-            add_offense(node, :location => :expression, :message => MESSAGE)
+            add_offense(node, location: :expression, message: MESSAGE)
           end
         end
 

--- a/lib/rubocop/cop/root_cops/must_include.rb
+++ b/lib/rubocop/cop/root_cops/must_include.rb
@@ -35,7 +35,7 @@ module RuboCop
 
         def investigate_post_walk(_processed_source)
           if search_for_inclusion? && !@proper_module_is_included
-            add_offense(@class_node, :location => :expression, :message => "Classes in this directory must include #{@module_to_include} module")
+            add_offense(@class_node, location: :expression, message: "Classes in this directory must include #{@module_to_include} module")
           end
         end
 
@@ -63,8 +63,8 @@ module RuboCop
         def mapping
           @mapping ||= (cop_config["Mapping"] || []).map do |config|
             {
-              :glob => File.join("**", config["Dir"], "*.rb"),
-              :module => config["Module"]
+              glob: File.join("**", config["Dir"], "*.rb"),
+              module: config["Module"]
             }
           end
         end

--- a/lib/rubocop/cop/root_cops/must_inherit.rb
+++ b/lib/rubocop/cop/root_cops/must_inherit.rb
@@ -41,15 +41,15 @@ module RuboCop
           class_name = node.identifier.const_name
           superclass_name = node.parent_class&.const_name
           unless class_name_match?(class_name, superclass_name, class_options)
-            add_offense(node, :location => :expression, :message => "Classes in this directory must inherit from #{class_options_to_s(class_options)}")
+            add_offense(node, location: :expression, message: "Classes in this directory must inherit from #{class_options_to_s(class_options)}")
           end
         end
 
         def mapping
           @mapping ||= (cop_config["Mapping"] || []).map do |config|
             {
-              :glob => File.join("**", config["Dir"], "*.rb"),
-              :parent_class_options => [config["ParentClass"]].flatten
+              glob: File.join("**", config["Dir"], "*.rb"),
+              parent_class_options: [config["ParentClass"]].flatten
             }
           end
         end

--- a/lib/rubocop/cop/root_cops/no_backfills_in_data_migration.rb
+++ b/lib/rubocop/cop/root_cops/no_backfills_in_data_migration.rb
@@ -43,7 +43,7 @@ module RuboCop
           return if @is_collapsed_migration_class && method_name.to_s == "execute"
 
           if FORBIDDEN_METHODS.include?(method_name)
-            add_offense(node, :location => :expression, :message => MESSAGE)
+            add_offense(node, location: :expression, message: MESSAGE)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/no_index_on_add_column.rb
+++ b/lib/rubocop/cop/root_cops/no_index_on_add_column.rb
@@ -23,7 +23,7 @@ module RuboCop
 
           keys = last.keys.collect(&:value)
 
-          add_offense(node, :location => :expression, :message => MESSAGE) if keys.include?(:index)
+          add_offense(node, location: :expression, message: MESSAGE) if keys.include?(:index)
         end
       end
     end

--- a/lib/rubocop/cop/root_cops/no_tracers.rb
+++ b/lib/rubocop/cop/root_cops/no_tracers.rb
@@ -7,7 +7,7 @@ module RootCops
     PATTERN
 
     def on_send(node)
-      add_offense(node, :location => :selector) if tracer(node)
+      add_offense(node, location: :selector) if tracer(node)
     end
   end
 end

--- a/lib/rubocop/cop/root_cops/private_methods/called_private_method.rb
+++ b/lib/rubocop/cop/root_cops/private_methods/called_private_method.rb
@@ -8,7 +8,7 @@ module RuboCop
           def on_send(node)
             receiver, method_name = *node
             if receiver && (method_name =~ /^_/)
-              add_offense(node, :location => :selector, :message => MSG)
+              add_offense(node, location: :selector, message: MSG)
             end
           end
         end

--- a/lib/rubocop/cop/root_cops/private_methods/called_protected.rb
+++ b/lib/rubocop/cop/root_cops/private_methods/called_protected.rb
@@ -8,7 +8,7 @@ module RuboCop
           def on_send(node)
             _receiver, method_name = *node
             if method_name.to_s == "protected"
-              add_offense(node, :location => :selector, :message => MSG)
+              add_offense(node, location: :selector, message: MSG)
             end
           end
         end

--- a/lib/rubocop/cop/root_cops/private_methods/underscore_prefix.rb
+++ b/lib/rubocop/cop/root_cops/private_methods/underscore_prefix.rb
@@ -50,10 +50,10 @@ module RuboCop
             return if method_name.nil?
 
             if method_name =~ /^_/ && @visible
-              add_offense(node, :location => :expression, :message => NEED_PRIVATE)
+              add_offense(node, location: :expression, message: NEED_PRIVATE)
             end
             if method_name !~ /^_/ && !@visible
-              add_offense(node, :location => :expression, :message => NEED_UNDERSCORE)
+              add_offense(node, location: :expression, message: NEED_UNDERSCORE)
             end
           end
 

--- a/lib/rubocop/cop/root_cops/raise_i18n.rb
+++ b/lib/rubocop/cop/root_cops/raise_i18n.rb
@@ -8,7 +8,7 @@ module RuboCop
           return unless node.command?(:raise)
 
           node.child_nodes.each do |child|
-            add_offense(child, :location => :expression, :message => MESSAGE) if _str?(child)
+            add_offense(child, location: :expression, message: MESSAGE) if _str?(child)
           end
         end
 

--- a/lib/rubocop/cop/root_cops/retry_on_warning.rb
+++ b/lib/rubocop/cop/root_cops/retry_on_warning.rb
@@ -8,7 +8,7 @@ module RuboCop
           _receiver, method_name = *node
 
           if method_name == :retry_on
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/shared_context_name.rb
+++ b/lib/rubocop/cop/root_cops/shared_context_name.rb
@@ -23,7 +23,7 @@ module RuboCop
           method_args = *args[0]
           context_name = method_args[0].to_s
           unless context_name == @base_name || context_name.start_with?(@expected_context_prefix)
-            add_offense(node, :location => :expression, :message => PREFIX_OR_MATCH)
+            add_offense(node, location: :expression, message: PREFIX_OR_MATCH)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/spec_file_name.rb
+++ b/lib/rubocop/cop/root_cops/spec_file_name.rb
@@ -14,7 +14,7 @@ module RuboCop
           return unless receiver_name == :RSpec && method_name == :describe
 
           unless @file_path.end_with?("_spec.rb")
-            add_offense(node, :location => :expression, :message => FILE_NAME_ERROR)
+            add_offense(node, location: :expression, message: FILE_NAME_ERROR)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/unnecessary_aggregate_failures.rb
+++ b/lib/rubocop/cop/root_cops/unnecessary_aggregate_failures.rb
@@ -11,7 +11,7 @@ module RuboCop
         def on_sym(node)
           return unless node.value == :aggregate_failures && it_block?(node.parent)
 
-          add_offense(node, :location => :expression, :message => ERROR)
+          add_offense(node, location: :expression, message: ERROR)
         end
       end
     end

--- a/lib/rubocop/cop/root_cops/up_and_down_or_change.rb
+++ b/lib/rubocop/cop/root_cops/up_and_down_or_change.rb
@@ -12,7 +12,7 @@ module RuboCop
           return if methods.include?(:change)
           return if methods.include?(:up) && methods.include?(:down)
 
-          add_offense(node, :location => :expression, :message => MSG)
+          add_offense(node, location: :expression, message: MSG)
         end
 
         def_node_matcher :active_record_migration?, <<~PATTERN

--- a/lib/rubocop/cop/root_cops/use_before_action.rb
+++ b/lib/rubocop/cop/root_cops/use_before_action.rb
@@ -7,7 +7,7 @@ module RuboCop
         def on_send(node)
           _receiver, method_name = *node
           if method_name == :before_filter
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/use_detect.rb
+++ b/lib/rubocop/cop/root_cops/use_detect.rb
@@ -32,7 +32,7 @@ module RuboCop
 
         def on_block(node)
           find_called_with_a_block?(node) do
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
 
@@ -45,7 +45,7 @@ module RuboCop
 
         def on_send(node)
           find_called_with_a_block_as_proc?(node) do
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/use_envvars.rb
+++ b/lib/rubocop/cop/root_cops/use_envvars.rb
@@ -9,7 +9,7 @@ module RuboCop
           _, name = *receiver
 
           if name == :ENV && method_name == :[]
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/root_cops/use_lonely_operator.rb
+++ b/lib/rubocop/cop/root_cops/use_lonely_operator.rb
@@ -8,7 +8,7 @@ module RuboCop
           _receiver, method_name = *node
 
           if method_name == :try! && node.arguments?
-            add_offense(node, :location => :expression, :message => MSG)
+            add_offense(node, location: :expression, message: MSG)
           end
         end
       end

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = "root-ruby-style"
-  gem.version = "0.0.13"
+  gem.version = "0.0.14"
   gem.authors = ["Root Devs"]
   gem.email = ["devs@joinroot.com"]
 


### PR DESCRIPTION
## Notes
- This will NOT require JSON-style Ruby hashes in root-server until we update root-server to use this new gem version (0.0.14)

---

## Background
[Slack thread about the new hash syntax discussion](https://joinroot.slack.com/archives/C07783J1FAL/p1727877950567249) | [Slack message about requiring JSON-style hashes](https://joinroot.slack.com/archives/C07783J1FAL/p1731963579434569?thread_ts=1728584721.742629&cid=C07783J1FAL)

### Related PRs
- #72
- https://github.com/Root-App/root-monorepo/pull/64129

## Problem
In the PRs linked above, we introduced JSON-style Ruby hashes to root-server, but we made them optional. So, we were free to start writing hashes in the new syntax without having to convert all of our old hashes.

But there has been desire to _require_ the new JSON style, so this PR prepares for being able to do that!

## Solution
Stop allowing hash rockets and instead require JSON-style Ruby hashes (where possible).

This will result in an astronomical diff in root-server, but we plan to convert it all at once and then ignore that commit from git blames to not be too disruptive to future debugging. But, that will be handled in a following root-monorepo PR!