### PR TITLE
Bump gem version to 0.0.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.15)
+    root-ruby-style (0.0.16)
       activesupport (>= 5.0, < 8)
       rubocop (> 1.60)
       rubocop-performance (= 1.5.2)

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = "root-ruby-style"
-  gem.version = "0.0.15"
+  gem.version = "0.0.16"
   gem.authors = ["Root Devs"]
   gem.email = ["devs@joinroot.com"]
 


### PR DESCRIPTION
## Problem
In #76, I was hoping to rewrite history and get v0.0.15 to be overwritten with the change, but we skip publishing the gem if the version isn't updated as well.

## Solution
Just bump the version to get the change deployed from #76, so we can use it for root-server in a following PR