### PR TITLE
Bump rubocop to 1.76 and rename Naming/PredicateName accordingly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,7 @@ Metrics/PerceivedComplexity:
 
 # prefixes should be avoided before predicates in general, but they make sense
 # in some cases, particularly if an arg is being passed to the method
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.18)
+    root-ruby-style (0.0.19)
       activesupport (>= 5.0, < 8)
-      rubocop (~> 1.75)
+      rubocop (~> 1.76)
       rubocop-factory_bot (~> 2.27.1)
       rubocop-performance (~> 1.25.0)
       rubocop-rails (~> 2.31.0)
@@ -70,7 +70,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    rubocop (1.75.2)
+    rubocop (1.76.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -78,10 +78,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.44.0, < 2.0)
+      rubocop-ast (>= 1.45.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.1)
+    rubocop-ast (1.45.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-factory_bot (2.27.1)

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_runtime_dependency "activesupport", ">= 5.0", "< 8"
-  gem.add_runtime_dependency "rubocop", "~> 1.75"
+  gem.add_runtime_dependency "rubocop", "~> 1.76"
   gem.add_runtime_dependency "rubocop-factory_bot", "~> 2.27.1"
   gem.add_runtime_dependency "rubocop-performance", "~> 1.25.0"
   gem.add_runtime_dependency "rubocop-rails", "~> 2.31.0"


### PR DESCRIPTION
Rubocop 1.76 changed the name of Naming/PredicateName to Naming/PredicatePrefix.

The PR will prevent warnings from appearing in consuming apps that have upgraded Rubocop to 1.76 that inherit from .rubocop.yml in this gem.