### PR TITLE
Relax rubocop-rails pinning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.18)
+    root-ruby-style (0.0.19)
       activesupport (>= 5.0, < 8)
       rubocop (~> 1.75)
       rubocop-factory_bot (~> 2.27.1)
       rubocop-performance (~> 1.25.0)
-      rubocop-rails (~> 2.31.0)
+      rubocop-rails (~> 2.31)
       rubocop-rspec (~> 3.6.0)
 
 GEM

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rubocop", "~> 1.75"
   gem.add_runtime_dependency "rubocop-factory_bot", "~> 2.27.1"
   gem.add_runtime_dependency "rubocop-performance", "~> 1.25.0"
-  gem.add_runtime_dependency "rubocop-rails", "~> 2.31.0"
+  gem.add_runtime_dependency "rubocop-rails", "~> 2.31"
   gem.add_runtime_dependency "rubocop-rspec", "~> 3.6.0"
 
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This allows consumings apps to bump rubocop-rails beyond 2.31 if they wish, but they are not forced to do so.

rubocop-rails 2.32 includes an important update that allows Rails rubocop rules to apply correctly to files in nested folder structures, which is common in apps that use engines.

When a consuming app upgrades to 2.32 it likely will cause a sudden influx in Rails rubocop violations.