### PR TITLE
feat: enforce consistent multiline hash and argument formatting (v0.0.24)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,9 +41,6 @@ Layout/LineLength:
 Layout/MultilineHashKeyLineBreaks:
   Enabled: true
 
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: true
-
 Lint/Debugger:
   AutoCorrect: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,12 @@ Layout/EmptyLineAfterGuardClause:
 Layout/LineLength:
   Enabled: false
 
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
 Lint/Debugger:
   AutoCorrect: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### v0.0.24
 
-- Enable `Layout/MultilineHashKeyLineBreaks` and `Layout/MultilineMethodArgumentLineBreaks` to enforce consistent formatting when any key/arg in a multi-line hash or method call wraps to its own line.
+- Enable `Layout/MultilineHashKeyLineBreaks` to enforce that when any key in a multi-line hash literal wraps to its own line, all keys must do the same.
 
 ### v0.0.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.0.24
+
+- Enable `Layout/MultilineHashKeyLineBreaks` and `Layout/MultilineMethodArgumentLineBreaks` to enforce consistent formatting when any key/arg in a multi-line hash or method call wraps to its own line.
+
 ### v0.0.21
 
 - Update rack version.  See #87.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    root-ruby-style (0.0.23)
+    root-ruby-style (0.0.24)
       activesupport (>= 5.0)
       rubocop (~> 1.76)
       rubocop-factory_bot (~> 2.27.1)
@@ -118,6 +118,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/root-ruby-style.gemspec
+++ b/root-ruby-style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = "root-ruby-style"
-  gem.version = "0.0.23"
+  gem.version = "0.0.24"
   gem.authors = ["Root Devs"]
   gem.email = ["devs@joinroot.com"]
 


### PR DESCRIPTION
## Summary

- Enables `Layout/MultilineHashKeyLineBreaks` — if any key in a multi-line hash literal is on its own line, all keys must be
- Bumps gem version to `0.0.24`
- `Layout/MultilineMethodArgumentLineBreaks` was evaluated and **intentionally excluded**: it fires on legitimate patterns like lambdas as keyword arg values and `raise Foo, long_method_call(...)` constructs, producing worse formatting than the original code

## Example enforcement in root-monorepo

[Root-App/root-monorepo#75271](https://github.com/Root-App/root-monorepo/pull/75271) was created against this SHA to validate the autocorrect. It corrects **124 offenses across 13 files** — all genuine mixed hash key formatting, nothing else.

> *This PR description was generated by Claude.*